### PR TITLE
Refactor/tests and optimisation

### DIFF
--- a/gn2pg/__init__.py
+++ b/gn2pg/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import coloredlogs
 from pkg_resources import DistributionNotFound, get_distribution
 
-from . import metadata
+from gn2pg import metadata
 
 try:
     dist_name = "gn2pg_client"

--- a/gn2pg/api.py
+++ b/gn2pg/api.py
@@ -21,7 +21,7 @@ from urllib.parse import urlencode
 
 import requests
 
-from . import _, __version__
+from gn2pg import _, __version__
 
 logger = logging.getLogger("transfer_gn.geonature_api")
 

--- a/gn2pg/check_conf.py
+++ b/gn2pg/check_conf.py
@@ -8,9 +8,9 @@ from typing import Any, Dict
 from schema import Optional, Schema
 from toml import load
 
-from . import _, __version__
-from .env import ENVDIR
-from .utils import coalesce_in_dict, simplify
+from gn2pg import _, __version__
+from gn2pg.env import ENVDIR
+from gn2pg.utils import coalesce_in_dict, simplify
 
 logger = logging.getLogger("transfer_gn.check_conf")
 

--- a/gn2pg/download.py
+++ b/gn2pg/download.py
@@ -119,9 +119,7 @@ class DownloadGn:
             controler=self._api_instance.controler, last_ts=increment_ts
         )
 
-    def update(
-        self, since: str = None, actions: list = ["I", "U"]
-    ) -> None:
+    def update(self, since: str = None, actions: list = ["I", "U"]) -> None:
         """[summary]
 
         Args:

--- a/gn2pg/download.py
+++ b/gn2pg/download.py
@@ -13,8 +13,8 @@ Properties
 import logging
 from datetime import datetime
 
-from . import _, __version__
-from .api import DataAPI, DatasetsAPI
+from gn2pg import _, __version__
+from gn2pg.api import DataAPI, DatasetsAPI
 
 logger = logging.getLogger("transfer_gn.download_gn")
 

--- a/gn2pg/helpers.py
+++ b/gn2pg/helpers.py
@@ -12,11 +12,11 @@ from subprocess import call
 
 import pkg_resources
 
-from . import _
-from .download import Data
-from .env import ENVDIR
-from .store_postgresql import StorePostgresql
-from .utils import BColors
+from gn2pg import _
+from gn2pg.download import Data
+from gn2pg.env import ENVDIR
+from gn2pg.store_postgresql import StorePostgresql
+from gn2pg.utils import BColors
 
 logger = logging.getLogger(__name__)
 

--- a/gn2pg/main.py
+++ b/gn2pg/main.py
@@ -10,12 +10,12 @@ from logging.handlers import TimedRotatingFileHandler
 
 from toml import TomlDecodeError
 
-from . import _, __version__, metadata
-from .check_conf import Gn2PgConf
-from .env import ENVDIR, LOGDIR
-from .helpers import edit, full_download, init, update
-from .store_postgresql import PostgresqlUtils
-from .utils import BColors
+from gn2pg import _, __version__, metadata
+from gn2pg.check_conf import Gn2PgConf
+from gn2pg.env import ENVDIR, LOGDIR
+from gn2pg.helpers import edit, full_download, init, update
+from gn2pg.store_postgresql import PostgresqlUtils
+from gn2pg.utils import BColors
 
 logger = logging.getLogger(__name__)
 

--- a/gn2pg/store_postgresql.py
+++ b/gn2pg/store_postgresql.py
@@ -26,7 +26,7 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID, insert
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql import and_
 
-from . import _, __version__
+from gn2pg import _, __version__
 
 # logger = logging.getLogger("transfer_gn.store_postgresql")
 logger = logging.getLogger("transfer_gn.store_postgresql")

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,6 @@ Explanations:
 If the previous parameters of the postgreSQL container are used, the pytest
 command should be:
 
-`pytest --user=<my_user> --password=<my_password> --url=<my_url> --db-user=dbuser --db-password=dbpass --dbport=5434 tests`
+`pytest --user=<my_user> --password=<my_password> --url=<my_url> --db-user=dbuser --db-password=dbpass --db-port=5434 tests`
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ To be able to launch tests, the following arguments must be provided:
 - db-user (admin user of the database)
 - db-password (password of the db-user)
 - db-port (port number of the database)
+- export-id (id of the export)
 
 ### Before launching tests...
 A Postgresql database must be running on the port which will be specified.
@@ -30,6 +31,6 @@ Explanations:
 If the previous parameters of the postgreSQL container are used, the pytest
 command should be:
 
-`pytest --user=<my_user> --password=<my_password> --url=<my_url> --db-user=dbuser --db-password=dbpass --db-port=5434 tests`
+`pytest --user=<my_user> --password=<my_password> --url=<my_url> --db-user=dbuser --db-password=dbpass --db-port=5434 --export-id=1 tests`
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ To be able to launch tests, the following arguments must be provided:
 A Postgresql database must be running on the port which will be specified.
 One can run a database easily with docker:
 
-`docker run --name postgresgn2pg -e POSTGRES_USER=dbuser -e POSTGRES_PASSWORD=dbpass -p 5434:5432 -d postgres:14.5-alpine`
+`docker run --name postgresgn2pg -e POSTGRES_USER=dbuser -e POSTGRES_PASSWORD=dbpass -p 5434:5432 -d postgis/postgis:14-3.3-alpine`
 
 Explanations:
 - `--name`: name of the container
@@ -23,7 +23,7 @@ Explanations:
 - `-p 5434:5432`: exposes the port 5432 of the container to the local port 5434
   (you can change this if you wish)
 - `-d`: detached mode, the container run "in background"
-- `postgres:14.5-alpine`: name of the image to run into the container
+- `postgis/postgis:14-3.3-alpine`: name of the image to run into the container
 
 ### Lauching the tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,7 @@ To be able to launch tests, the following arguments must be provided:
 - db-password (password of the db-user)
 - db-port (port number of the database)
 - export-id (id of the export)
+- nb-threads (number of threads to use for parallelisation)
 
 ### Before launching tests...
 A Postgresql database must be running on the port which will be specified.
@@ -31,6 +32,6 @@ Explanations:
 If the previous parameters of the postgreSQL container are used, the pytest
 command should be:
 
-`pytest --user=<my_user> --password=<my_password> --url=<my_url> --db-user=dbuser --db-password=dbpass --db-port=5434 --export-id=1 tests`
+`pytest --user=<my_user> --password=<my_password> --url=<my_url> --db-user=dbuser --db-password=dbpass --db-port=5434 --export-id=1 --nb-threads=1 tests`
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ def pytest_addoption(parser):
     parser.addoption("--db-password", action="store", default="dbpwd")
     parser.addoption("--db-port", action="store", default=5432)
     parser.addoption("--db-name", action="store", default="testgn2pg_test")
+    parser.addoption("--export-id", action="store", default=1)
 
 
 pytest_plugins = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ def pytest_addoption(parser):
     parser.addoption("--db-port", action="store", default=5432)
     parser.addoption("--db-name", action="store", default="testgn2pg_test")
     parser.addoption("--export-id", action="store", default=1)
+    parser.addoption("--nb-threads", action="store", default=1)
 
 
 pytest_plugins = [

--- a/tests/fixtures/check_conf.py
+++ b/tests/fixtures/check_conf.py
@@ -15,6 +15,7 @@ def toml_conf(pytestconfig):
     db_password = pytestconfig.getoption("db_password")
     db_port = int(pytestconfig.getoption("db_port"))
     db_name = pytestconfig.getoption("db_name")
+    export_id = pytestconfig.getoption("export_id")
     toml_str = f"""
     [db]
     db_host = "localhost"
@@ -42,7 +43,7 @@ def toml_conf(pytestconfig):
     # GeoNature source URL
     url = "{url}"
     # GeoNature source Export id
-    export_id = 1
+    export_id = {export_id}
     # Data type (used to distinct datas and to conditionning triggers)
     data_type = "synthese_with_metadata"
 

--- a/tests/fixtures/check_conf.py
+++ b/tests/fixtures/check_conf.py
@@ -16,6 +16,7 @@ def toml_conf(pytestconfig):
     db_port = int(pytestconfig.getoption("db_port"))
     db_name = pytestconfig.getoption("db_name")
     export_id = pytestconfig.getoption("export_id")
+    nb_threads = pytestconfig.getoption("nb_threads")
     toml_str = f"""
     [db]
     db_host = "localhost"
@@ -54,6 +55,8 @@ def toml_conf(pytestconfig):
     # - 0 means unlimited
     # - >0 limit number of API requests
     max_requests = 0
+    # Number of computing threads
+    nb_threads = {nb_threads}
     """
 
     return toml_str

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -9,6 +9,6 @@ class TestDownload:
 
         assert now.strftime("%d/%m/%Y %H") == increment.strftime("%d/%m/%Y %H")
         assert (
-            "items have been stored in db from data of source"
-            in caplog.records[-1].message
+            "items have been stored in db from data of source" in caplog.text
         )
+        assert "100.00 %" in caplog.text


### PR DESCRIPTION
# Contexte
Dans le cadre d'une prestation avec le Parc National des Ecrins pour le SINP, des optimisations ont été proposées afin d'accélérer l'exécution du module GN2PG (voir #27).


# Fonctionnalités/refactorisations développées

## Optimisation du calcul des pages

1. La génération de la `page_list` pouvait occuper de la mémoire si beaucoup de pages devaient être générées. Cette "liste" a donc été remplacée par un Générateur/Itérateur.

2. Un `limit=1` "en dur" a été ajouté dans le calcul de `page_list` pour éviter d'appeler l'API d'export avec le paramètre `max_page_length` fourni en configuration. Cela permet d'accélérer considérablement le calcul du nombre de données total effectué avant le téléchargement des données. 

3. Le paramètre `limit` était initialement passé via une liste de tuples. Maintenant, le passage de paramètres se fait via un dictionnaire afin de faciliter l'accès aux valeurs. Le code a été adapté à ce nouveau type. Cette modification facilitera également la potentielle utilisation du paramètre `params` dans la méthode `get` de la librairie `requests`.

4. Par la même occasion, la fonction `math.ceil` a remplacé `math.floor + 1` dans le calcul du nombre de pages qui ne 
fonctionnait pas si le reste de la division du nombre de données avec la limite était nul. 

## Mutualisation du code

Les portions de code répétées ont été mises dans une fonction. Ainsi, la fonction `process_progress` a été créée dans `download.py`. Elle est appelée par les fonctions `store` et `update`.

## Suppression de variables non utilisées

Quelques variables étaient calculées sans être utilisées, elles ont été supprimées.

## Simplication de la syntaxe
Lorsque cela était possible, la syntaxe a été simplifiée pour supprimer des étapes intermédiaires.

## Modification des fonctions NoReturn
De nombreuses fonctions du `store_postgresql.py` et quelques fonctions du `main.py` avaient comme type de retour un `NoReturn`. Or ces fonctions retournaient par défaut à minima `None`. Leurs types de retour ont donc été modifiés en `None`.

## Tests

Ajout de tests et réparation des 2 tests existants :
- Ajout de fixtures
- Ajout d'une fixture utilisée automatiquement pour initialiser la base de données

Comme indiqué dans `tests/README.md`, la session de tests est paramétrable. C'est à dire qu'il faut renseigner des paramètres pour pouvoir lancer pytest. Ces paramètres sont les informations sur l'export et sur la base de données où seront stockées les données téléchargées.

# Perspectives

Tests: 
- Ajouter de nombreux tests pour couvrir davantage de lignes de codes
- Voir comment mocker les appels à l'API d'un export pour ne pas surcharger le serveur :
  - Créer un faux serveur ?
  - Utiliser `pytest-mock` ?

Github Actions:
- Lancer les tests automatiquement (possible si API export mockée ou autre) et calculer le coverage
- Lancer le linting + black + isort
- Publier le package automatiquement

Requests:
- Utiliser davantage le paramètre `params` des fonctions de requests (get, post).
- Donc éventuellement, ne pas générer la `page_list` en avance 

DB:
- Généraliser l'interface vers Postgresql pour permettre de stocker dans un autre type de   base de données (type sqlite pour plus de portabilité) ou tout autre type


Cette PR pose les bases d'une autre PR sur la parallélisation des requêtes (#30) dont elle dépend.

# Questions

Est-ce que la façon dont sont exécutés les tests vous convient ?

En espérant que tout le reste vous convienne aussi !

---
Lié à #27

Avec @mvergez