### PR TITLE
Fix/pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,14 +32,13 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: pylint
+        entry: poetry run pylint
         language: system
         types: [python]
         args:
           [
             "-rn", # Only display messages
             "-sn", # Don't display the score
-            "--rcfile=pylintrc", # Link to your config file
             "--load-plugins=pylint.extensions.docparams", # Load an extension
           ]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: ['click<8.1']
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/gn2pg/app/app.py
+++ b/gn2pg/app/app.py
@@ -14,11 +14,13 @@ from gn2pg.app.models import DownloadLog, ErrorLog, IncrementLog
 def create_app(config=FlaskConfig):
     """Create app"""
 
-    app = Flask(__name__, static_url_path=config.APPLICATION_ROOT)
+    app = Flask(__name__, static_url_path=config.application_root)
     app.config.from_object(config)
+    app.config["SQLALCHEMY_DATABASE_URI"] = config.sqlalchemy_database_uri
+    app.config["APPLICATION_ROOT"] = config.application_root
     app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1)
     db.init_app(app)
-    app.config["DB"] = db
+    app.config["db"] = db
     url_base = app.config["APPLICATION_ROOT"]
     admin = Admin(
         app,
@@ -36,5 +38,5 @@ def create_app(config=FlaskConfig):
 
 
 if __name__ == "__main__":
-    app = create_app()
-    app.run()
+    app_dev = create_app()
+    app_dev.run()

--- a/gn2pg/app/config.py
+++ b/gn2pg/app/config.py
@@ -50,23 +50,26 @@ APPLICATION_ROOT = settings_config("APPLICATION_ROOT", default="/gn2pg")
 class AppConfig:
     """App config class"""
 
-    ENV: str
-    APPLICATION_ROOT: str
-    DEBUG: bool
-    SQLALCHEMY_DATABASE_URI: str
-    DATABASE: dict
+    env: str
+    application_root: str
+    debug: bool
+    sqlalchemy_database_uri: str
+    database: dict
 
     def __init__(self):
-        self.ENV = ENV
-        self.APPLICATION_ROOT = APPLICATION_ROOT
-        self.DEBUG = DEBUG
-        self.DATABASE = DATABASES["default"]
+        self.env = ENV
+        self.application_root = APPLICATION_ROOT
+        self.debug = DEBUG
+        self.database = DATABASES["default"]
         self.set_database_uri()
 
     def set_database_uri(self):
         """define database uri"""
-        DB = self.DATABASE
-        self.SQLALCHEMY_DATABASE_URI = f"{DB['ENGINE']}://{DB['USER']}:{DB['PASSWORD']}@{DB['HOST']}:{DB['PORT']}/{DB['NAME']}"
+        db = self.database
+        self.sqlalchemy_database_uri = (
+            f"{db['ENGINE']}://"
+            + f"{db['USER']}:{db['PASSWORD']}@{db['HOST']}:{db['PORT']}/{db['NAME']}"
+        )
 
 
 FlaskConfig = AppConfig()

--- a/gn2pg/app/env.py
+++ b/gn2pg/app/env.py
@@ -1,3 +1,4 @@
+"""Module providing constant environment variable path directory."""
 from pathlib import Path
 
 # DIRECTORY FOR SETTINGS.INI

--- a/gn2pg/app/models.py
+++ b/gn2pg/app/models.py
@@ -1,3 +1,4 @@
+"""Module providing Models according to database from config file."""
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 

--- a/gn2pg/app/utils/admin_views.py
+++ b/gn2pg/app/utils/admin_views.py
@@ -5,14 +5,14 @@ import json
 from jinja2.utils import markupsafe
 
 
-def json_formatter(view, context, model, name):
+def json_formatter(_0, _1, model, name):
     """Prettify JSON data in flask admin lists"""
     value = getattr(model, name)
     json_value = json.dumps(value, ensure_ascii=False, indent=2)
     return markupsafe.Markup(f"<pre class='ctn-row-long-text'>{json_value}</pre>")
 
 
-def add_class_ctn_row_long_text_formatter(view, context, model, name):
+def add_class_ctn_row_long_text_formatter(_0, _1, model, name):
     """Prettify long text data in flask admin lists"""
     value = getattr(model, name)
     return markupsafe.Markup(f"<pre class='ctn-row-long-text'>{value}</pre>")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,8 @@ disable = """
     too-many-instance-attributes,
     too-few-public-methods
 """
+good-names=["i","j" ,"k","ex","Run","_","db"]
+
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
**fix: config pre commit and pylint**

- Change `pre-commit-config.yaml` in order to use pylint from the project config
 So I delete the link to pyltinrc in order to use the config pylint in
`pyproject.toml`
- Change `good-names` argument to allow 'db' variable (usually Pylint
  default allow only minimum length 3 for variable and defaults :
("i","j" ,"k","ex","Run","_")

Reviewed-by: andriac
[Refs_PR] : https://github.com/lpoaura/GN2PG/pull/42




**fix: error with version isort for pre-commit**

When want to commit I got an error .
Solved by changing isort version in `.pre-commit-config.yaml`
(source link problem
https://github.com/home-assistant/core/issues/86892)

See if problem is the same for others

Reviewed-by: andriac