### PR TITLE
Refactor/tognsynthese optimisation

### DIFF
--- a/gn2pg/data/to_gnsynthese.sql
+++ b/gn2pg/data/to_gnsynthese.sql
@@ -161,809 +161,8 @@ COMMENT ON FUNCTION gn2pg_import.fct_c_get_id_nomenclature_from_label (_type TEX
 CREATE UNIQUE INDEX IF NOT EXISTS uidx_synthese_id_source_id_entity_source_pk_value ON gn_synthese.synthese (id_source, entity_source_pk_value)
 ;
 
-/* UPSERT INTO Synthese when type is "synthese_with_label */
-DROP TRIGGER IF EXISTS tri_c_upsert_data_to_geonature_with_nomenclature_label ON gn2pg_import.data_json
-;
-
-DROP FUNCTION IF EXISTS gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_nomenclature_label () CASCADE
-;
-
-CREATE OR REPLACE FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_nomenclature_label()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-AS
-$func$
-DECLARE
-    _local_srid                              INT;
-    the_unique_id_sinp                       UUID;
-    the_unique_id_sinp_grp                   UUID;
-    the_id_source                            INT;
-    the_entity_source_pk_value               INT;
-    the_id_af                                INT;
-    the_id_dataset                           INT;
-    the_id_nomenclature_geo_object_nature    INT;
-    the_id_nomenclature_grp_typ              INT;
-    the_grp_method                           VARCHAR;
-    the_id_nomenclature_obs_technique        INT;
-    the_id_nomenclature_bio_status           INT;
-    the_id_nomenclature_bio_condition        INT;
-    the_id_nomenclature_naturalness          INT;
-    the_id_nomenclature_exist_proof          INT;
-    the_id_nomenclature_valid_status         INT;
-    the_id_nomenclature_diffusion_level      INT;
-    the_id_nomenclature_life_stage           INT;
-    the_id_nomenclature_sex                  INT;
-    the_id_nomenclature_obj_count            INT;
-    the_id_nomenclature_type_count           INT;
-    the_id_nomenclature_sensitivity          INT;
-    the_id_nomenclature_observation_status   INT;
-    the_id_nomenclature_blurring             INT;
-    the_id_nomenclature_source_status        INT;
-    the_id_nomenclature_info_geo_type        INT;
-    the_id_nomenclature_behaviour            INT;
-    the_id_nomenclature_biogeo_status        INT;
-    the_reference_biblio                     VARCHAR;
-    the_count_min                            INT;
-    the_count_max                            INT;
-    the_cd_nom                               INT;
-    the_cd_hab                               INT;
-    the_nom_cite                             VARCHAR;
-    the_meta_v_taxref                        VARCHAR;
-    the_sample_number_proof                  TEXT;
-    the_digital_proof                        TEXT;
-    the_non_digital_proof                    TEXT;
-    the_altitude_min                         INT;
-    the_altitude_max                         INT;
-    the_depth_min                            INT;
-    the_depth_max                            INT;
-    the_place_name                           VARCHAR;
-    _the_geom_4326                           GEOMETRY;
-    _the_geom_point                          GEOMETRY;
-    _the_geom_local                          GEOMETRY;
-    the_precision                            INT;
-    the_date_min                             TIMESTAMP;
-    the_date_max                             TIMESTAMP;
-    the_validator                            VARCHAR;
-    the_validation_comment                   TEXT;
-    the_observers                            TEXT;
-    the_determiner                           TEXT;
-    the_id_digitiser                         INT;
-    the_id_nomenclature_determination_method INT;
-    the_comment_context                      TEXT;
-    the_comment_description                  TEXT;
-    the_additional_data                      JSONB;
-    the_meta_validation_date                 TIMESTAMP;
-BEGIN
-    SELECT find_srid('gn_synthese', 'synthese', 'the_geom_local')
-    INTO _local_srid;
-    SELECT new.uuid
-    INTO the_unique_id_sinp;
-    SELECT cast(new.item #>> '{id_perm_grp_sinp}' AS UUID)
-    INTO the_unique_id_sinp_grp;
-    SELECT gn2pg_import.fct_c_get_or_insert_source(new.source)
-    INTO the_id_source;
-    SELECT new.item #>> '{id_synthese}'
-    INTO the_entity_source_pk_value;
-    SELECT gn2pg_import.fct_c_get_or_insert_basic_af_from_uuid_name(cast(new.item #>> '{ca_uuid}' AS UUID),
-                                                                    new.item #>> '{ca_nom}')
-    INTO the_id_af;
-    SELECT gn2pg_import.fct_c_get_or_insert_basic_dataset_from_uuid_name(cast(new.item #>> '{jdd_uuid}' AS UUID),
-                                                                         new.item #>> '{jdd_nom}', the_id_af)
-    INTO the_id_dataset;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('NAT_OBJ_GEO', new.item #>> '{nature_objet_geo}')
-    INTO the_id_nomenclature_geo_object_nature;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('TYP_GRP', new.item #>> '{type_regroupement}')
-    INTO the_id_nomenclature_grp_typ;
-    SELECT new.item #>> '{methode_regroupement}'
-    INTO the_grp_method;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('METH_OBS', new.item #>> '{technique_obs}')
-    INTO the_id_nomenclature_obs_technique;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_BIO', new.item #>> '{statut_biologique}')
-    INTO the_id_nomenclature_bio_status;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('ETA_BIO', new.item #>> '{etat_biologique}')
-    INTO the_id_nomenclature_bio_condition;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('NATURALITE', new.item #>> '{naturalite}')
-    INTO the_id_nomenclature_naturalness;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('PREUVE_EXIST', new.item #>> '{preuve_existante}')
-    INTO the_id_nomenclature_exist_proof;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_VALID', new.item #>> '{statut_validation}')
-    INTO the_id_nomenclature_valid_status;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('NIV_PRECIS', new.item #>> '{precision_diffusion}')
-    INTO the_id_nomenclature_diffusion_level;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('STADE_VIE', new.item #>> '{stade_vie}')
-    INTO the_id_nomenclature_life_stage;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('SEXE', new.item #>> '{sexe}')
-    INTO the_id_nomenclature_sex;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('OBJ_DENBR', new.item #>> '{objet_denombrement}')
-    INTO the_id_nomenclature_obj_count;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('TYP_DENBR', new.item #>> '{type_denombrement}')
-    INTO the_id_nomenclature_type_count;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('SENSIBILITE', new.item #>> '{niveau_sensibilite}')
-    INTO the_id_nomenclature_sensitivity;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_OBS', new.item #>> '{statut_observation}')
-    INTO the_id_nomenclature_observation_status;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('DEE_FLOU', new.item #>> '{floutage_dee}')
-    INTO the_id_nomenclature_blurring;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_SOURCE', new.item #>> '{statut_source}')
-    INTO the_id_nomenclature_source_status;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('TYP_INF_GEO', new.item #>> '{type_info_geo}')
-    INTO the_id_nomenclature_info_geo_type;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('OCC_COMPORTEMENT', new.item #>> '{comportement}')
-    INTO the_id_nomenclature_behaviour;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('STAT_BIOGEO', new.item #>> '{statut_biogeo}')
-    INTO the_id_nomenclature_biogeo_status;
-    SELECT new.item #>> '{reference_biblio}'
-    INTO the_reference_biblio;
-    SELECT new.item #>> '{nombre_min}'
-    INTO the_count_min;
-    SELECT new.item #>> '{nombre_max}'
-    INTO the_count_max;
-    SELECT new.item #>> '{cd_nom}'
-    INTO the_cd_nom;
-    SELECT new.item #>> '{cd_hab}'
-    INTO the_cd_hab;
-    SELECT new.item #>> '{nom_cite}'
-    INTO the_nom_cite;
-    SELECT new.item #>> '{version_taxref}'
-    INTO the_meta_v_taxref;
-    SELECT new.item #>> '{numero_preuve}'
-    INTO the_sample_number_proof;
-    SELECT new.item #>> '{preuve_numerique}'
-    INTO the_digital_proof;
-    SELECT new.item #>> '{preuve_non_numerique}'
-    INTO the_non_digital_proof;
-    SELECT new.item #>> '{altitude_min}'
-    INTO the_altitude_min;
-    SELECT new.item #>> '{altitude_max}'
-    INTO the_altitude_max;
-    SELECT new.item #>> '{profondeur_min}'
-    INTO the_depth_min;
-    SELECT new.item #>> '{profondeur_max}'
-    INTO the_depth_max;
-    SELECT new.item #>> '{nom_lieu}'
-    INTO the_place_name;
-    SELECT st_setsrid(st_geomfromtext(new.item #>> '{wkt_4326}'), 4326)
-    INTO _the_geom_4326;
-    SELECT st_centroid(_the_geom_4326)
-    INTO _the_geom_point;
-    SELECT st_transform(_the_geom_4326, _local_srid)
-    INTO _the_geom_local;
-    SELECT cast(new.item #>> '{precision}' AS INT)
-    INTO the_precision;
-    SELECT cast(new.item #>> '{date_debut}' AS DATE)
-    INTO the_date_min;
-    SELECT cast(new.item #>> '{date_fin}' AS DATE)
-    INTO the_date_max;
-    SELECT new.item #>> '{validateur}'
-    INTO the_validator;
-    SELECT new.item #>> '{comment_validation}'
-    INTO the_validation_comment;
-    SELECT new.item #>> '{observateurs}'
-    INTO the_observers;
-    SELECT new.item #>> '{determinateur}'
-    INTO the_determiner;
-    SELECT NULL
-    INTO the_id_digitiser;
-    SELECT gn2pg_import.fct_c_get_id_nomenclature_from_label('TYPE', new.item #>> '{label}')
-    INTO the_id_nomenclature_determination_method;
-    SELECT new.item #>> '{comment_releve}'
-    INTO the_comment_context;
-    SELECT new.item #>> '{comment_occurence}'
-    INTO the_comment_description;
-    SELECT NULL
-    INTO the_additional_data;
-    SELECT NULL
-    INTO the_meta_validation_date;
-    INSERT INTO gn_synthese.synthese ( unique_id_sinp
-                                     , unique_id_sinp_grp
-                                     , id_source
-                                     , entity_source_pk_value
-                                     , id_dataset
-                                     , id_nomenclature_geo_object_nature
-                                     , id_nomenclature_grp_typ
-                                     , grp_method
-                                     , id_nomenclature_obs_technique
-                                     , id_nomenclature_bio_status
-                                     , id_nomenclature_bio_condition
-                                     , id_nomenclature_naturalness
-                                     , id_nomenclature_exist_proof
-                                     , id_nomenclature_valid_status
-                                     , id_nomenclature_diffusion_level
-                                     , id_nomenclature_life_stage
-                                     , id_nomenclature_sex
-                                     , id_nomenclature_obj_count
-                                     , id_nomenclature_type_count
-                                     , id_nomenclature_sensitivity
-                                     , id_nomenclature_observation_status
-                                     , id_nomenclature_blurring
-                                     , id_nomenclature_source_status
-                                     , id_nomenclature_info_geo_type
-                                     , id_nomenclature_behaviour
-                                     , id_nomenclature_biogeo_status
-                                     , reference_biblio
-                                     , count_min
-                                     , count_max
-                                     , cd_nom
-                                     , cd_hab
-                                     , nom_cite
-                                     , meta_v_taxref
-                                     , sample_number_proof
-                                     , digital_proof
-                                     , non_digital_proof
-                                     , altitude_min
-                                     , altitude_max
-                                     , depth_min
-                                     , depth_max
-                                     , place_name
-                                     , the_geom_4326
-                                     , the_geom_point
-                                     , the_geom_local
-                                     , precision
-                                     , date_min
-                                     , date_max
-                                     , validator
-                                     , validation_comment
-                                     , observers
-                                     , determiner
-                                     , id_digitiser
-                                     , id_nomenclature_determination_method
-                                     , comment_context
-                                     , comment_description
-                                     , additional_data
-                                     , meta_validation_date
-                                     , last_action)
-    VALUES ( the_unique_id_sinp
-           , the_unique_id_sinp_grp
-           , the_id_source
-           , the_entity_source_pk_value
-           , the_id_dataset
-           , the_id_nomenclature_geo_object_nature
-           , the_id_nomenclature_grp_typ
-           , the_grp_method
-           , the_id_nomenclature_obs_technique
-           , the_id_nomenclature_bio_status
-           , the_id_nomenclature_bio_condition
-           , the_id_nomenclature_naturalness
-           , the_id_nomenclature_exist_proof
-           , the_id_nomenclature_valid_status
-           , the_id_nomenclature_diffusion_level
-           , the_id_nomenclature_life_stage
-           , the_id_nomenclature_sex
-           , the_id_nomenclature_obj_count
-           , the_id_nomenclature_type_count
-           , the_id_nomenclature_sensitivity
-           , the_id_nomenclature_observation_status
-           , the_id_nomenclature_blurring
-           , the_id_nomenclature_source_status
-           , the_id_nomenclature_info_geo_type
-           , the_id_nomenclature_behaviour
-           , the_id_nomenclature_biogeo_status
-           , the_reference_biblio
-           , the_count_min
-           , the_count_max
-           , the_cd_nom
-           , the_cd_hab
-           , the_nom_cite
-           , the_meta_v_taxref
-           , the_sample_number_proof
-           , the_digital_proof
-           , the_non_digital_proof
-           , the_altitude_min
-           , the_altitude_max
-           , the_depth_min
-           , the_depth_max
-           , the_place_name
-           , _the_geom_4326
-           , _the_geom_point
-           , _the_geom_local
-           , the_precision
-           , the_date_min
-           , the_date_max
-           , the_validator
-           , the_validation_comment
-           , the_observers
-           , the_determiner
-           , the_id_digitiser
-           , the_id_nomenclature_determination_method
-           , the_comment_context
-           , the_comment_description
-           , the_additional_data
-           , the_meta_validation_date
-           , 'I')
-    ON CONFLICT (id_source, entity_source_pk_value)
-        DO UPDATE SET unique_id_sinp                       = the_unique_id_sinp
-                    , unique_id_sinp_grp                   = the_unique_id_sinp_grp
-                    , id_source                            = the_id_source
-                    , entity_source_pk_value               = the_entity_source_pk_value
-                    , id_dataset                           = the_id_dataset
-                    , id_nomenclature_geo_object_nature    = the_id_nomenclature_geo_object_nature
-                    , id_nomenclature_grp_typ              = the_id_nomenclature_grp_typ
-                    , grp_method                           = the_grp_method
-                    , id_nomenclature_obs_technique        = the_id_nomenclature_obs_technique
-                    , id_nomenclature_bio_status           = the_id_nomenclature_bio_status
-                    , id_nomenclature_bio_condition        = the_id_nomenclature_bio_condition
-                    , id_nomenclature_naturalness          = the_id_nomenclature_naturalness
-                    , id_nomenclature_exist_proof          = the_id_nomenclature_exist_proof
-                    , id_nomenclature_valid_status         = the_id_nomenclature_valid_status
-                    , id_nomenclature_diffusion_level      = the_id_nomenclature_diffusion_level
-                    , id_nomenclature_life_stage           = the_id_nomenclature_life_stage
-                    , id_nomenclature_sex                  = the_id_nomenclature_sex
-                    , id_nomenclature_obj_count            = the_id_nomenclature_obj_count
-                    , id_nomenclature_type_count           = the_id_nomenclature_type_count
-                    , id_nomenclature_sensitivity          = the_id_nomenclature_sensitivity
-                    , id_nomenclature_observation_status   = the_id_nomenclature_observation_status
-                    , id_nomenclature_blurring             = the_id_nomenclature_blurring
-                    , id_nomenclature_source_status        = the_id_nomenclature_source_status
-                    , id_nomenclature_info_geo_type        = the_id_nomenclature_info_geo_type
-                    , id_nomenclature_behaviour            = the_id_nomenclature_behaviour
-                    , id_nomenclature_biogeo_status        = the_id_nomenclature_biogeo_status
-                    , reference_biblio                     = the_reference_biblio
-                    , count_min                            = the_count_min
-                    , count_max                            = the_count_max
-                    , cd_nom                               = the_cd_nom
-                    , cd_hab                               = the_cd_hab
-                    , nom_cite                             = the_nom_cite
-                    , meta_v_taxref                        = the_meta_v_taxref
-                    , sample_number_proof                  = the_sample_number_proof
-                    , digital_proof                        = the_digital_proof
-                    , non_digital_proof                    = the_non_digital_proof
-                    , altitude_min                         = the_altitude_min
-                    , altitude_max                         = the_altitude_max
-                    , depth_min                            = the_depth_min
-                    , depth_max                            = the_depth_max
-                    , place_name                           = the_place_name
-                    , the_geom_4326                        = _the_geom_4326
-                    , the_geom_point                       = _the_geom_point
-                    , the_geom_local                       = _the_geom_local
-                    , precision                            = the_precision
-                    , date_min                             = the_date_min
-                    , date_max                             = the_date_max
-                    , validator                            = the_validator
-                    , validation_comment                   = the_validation_comment
-                    , observers                            = the_observers
-                    , determiner                           = the_determiner
-                    , id_digitiser                         = the_id_digitiser
-                    , id_nomenclature_determination_method = the_id_nomenclature_determination_method
-                    , comment_context                      = the_comment_context
-                    , comment_description                  = the_comment_description
-                    , additional_data                      = the_additional_data
-                    , meta_validation_date                 = the_meta_validation_date
-                    , last_action                          = 'U';
-    RETURN new;
-END;
-$func$
-;
-
-COMMENT ON FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_nomenclature_label () IS 'Trigger function to upsert datas from import to synthese'
-;
-
-DROP TRIGGER IF EXISTS tri_c_upsert_data_to_geonature_with_nomenclature_label ON gn2pg_import.data_json
-;
-
-CREATE TRIGGER tri_c_upsert_data_to_geonature_with_nomenclature_label
-    AFTER INSERT OR UPDATE
-    ON gn2pg_import.data_json
-    FOR EACH ROW
-    WHEN (new.type LIKE 'synthese_with_label')
-EXECUTE PROCEDURE gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_nomenclature_label()
-;
 
 
-/* UPSERT INTO Synthese when type is "synthese_with_cd_nomenclature" */
-DROP TRIGGER IF EXISTS tri_c_upsert_data_to_geonature_with_cd_nomenclature ON gn2pg_import.data_json
-;
-
-DROP FUNCTION IF EXISTS gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_cd_nomenclature () CASCADE
-;
-
-CREATE OR REPLACE FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_cd_nomenclature()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-AS
-$func$
-DECLARE
-    _local_srid                              INT;
-    the_unique_id_sinp                       UUID;
-    the_unique_id_sinp_grp                   UUID;
-    the_id_source                            INT;
-    the_entity_source_pk_value               INT;
-    the_id_af                                INT;
-    the_id_dataset                           INT;
-    the_id_nomenclature_geo_object_nature    INT;
-    the_id_nomenclature_grp_typ              INT;
-    the_grp_method                           VARCHAR;
-    the_id_nomenclature_obs_technique        INT;
-    the_id_nomenclature_bio_status           INT;
-    the_id_nomenclature_bio_condition        INT;
-    the_id_nomenclature_naturalness          INT;
-    the_id_nomenclature_exist_proof          INT;
-    the_id_nomenclature_valid_status         INT;
-    the_id_nomenclature_diffusion_level      INT;
-    the_id_nomenclature_life_stage           INT;
-    the_id_nomenclature_sex                  INT;
-    the_id_nomenclature_obj_count            INT;
-    the_id_nomenclature_type_count           INT;
-    the_id_nomenclature_sensitivity          INT;
-    the_id_nomenclature_observation_status   INT;
-    the_id_nomenclature_blurring             INT;
-    the_id_nomenclature_source_status        INT;
-    the_id_nomenclature_info_geo_type        INT;
-    the_id_nomenclature_behaviour            INT;
-    the_id_nomenclature_biogeo_status        INT;
-    the_reference_biblio                     VARCHAR;
-    the_count_min                            INT;
-    the_count_max                            INT;
-    the_cd_nom                               INT;
-    the_cd_hab                               INT;
-    the_nom_cite                             VARCHAR;
-    the_meta_v_taxref                        VARCHAR;
-    the_sample_number_proof                  TEXT;
-    the_digital_proof                        TEXT;
-    the_non_digital_proof                    TEXT;
-    the_altitude_min                         INT;
-    the_altitude_max                         INT;
-    the_depth_min                            INT;
-    the_depth_max                            INT;
-    the_place_name                           VARCHAR;
-    _the_geom_4326                           GEOMETRY;
-    _the_geom_point                          GEOMETRY;
-    _the_geom_local                          GEOMETRY;
-    the_precision                            INT;
-    the_date_min                             TIMESTAMP;
-    the_date_max                             TIMESTAMP;
-    the_validator                            VARCHAR;
-    the_validation_comment                   TEXT;
-    the_observers                            TEXT;
-    the_determiner                           TEXT;
-    the_id_digitiser                         INT;
-    the_id_nomenclature_determination_method INT;
-    the_comment_context                      TEXT;
-    the_comment_description                  TEXT;
-    the_additional_data                      JSONB;
-    the_meta_validation_date                 TIMESTAMP;
-BEGIN
-    RAISE DEBUG 'Update synthese_with_cd_nomenclature';
-    SELECT find_srid('gn_synthese', 'synthese', 'the_geom_local')
-    INTO _local_srid;
-    SELECT new.uuid
-    INTO the_unique_id_sinp;
-    SELECT cast(new.item #>> '{id_perm_grp_sinp}' AS UUID)
-    INTO the_unique_id_sinp_grp;
-    SELECT gn2pg_import.fct_c_get_or_insert_source(new.source)
-    INTO the_id_source;
-    --     id_module                                INT;
-    SELECT new.item #>> '{id_synthese}'
-    INTO the_entity_source_pk_value;
-    SELECT gn2pg_import.fct_c_get_or_insert_basic_af_from_uuid_name(cast(new.item #>> '{ca_uuid}' AS UUID),
-                                                                    new.item #>> '{ca_nom}')
-    INTO the_id_af;
-    SELECT gn2pg_import.fct_c_get_or_insert_basic_dataset_from_uuid_name(cast(new.item #>> '{jdd_uuid}' AS UUID),
-                                                                         new.item #>> '{jdd_nom}', the_id_af)
-    INTO the_id_dataset;
-    SELECT ref_nomenclatures.get_id_nomenclature('NAT_OBJ_GEO', new.item #>> '{nature_objet_geo}')
-    INTO the_id_nomenclature_geo_object_nature;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYP_GRP', new.item #>> '{type_regroupement}')
-    INTO the_id_nomenclature_grp_typ;
-    SELECT new.item #>> '{methode_regroupement}'
-    INTO the_grp_method;
-    SELECT ref_nomenclatures.get_id_nomenclature('METH_OBS', new.item #>> '{technique_obs}')
-    INTO the_id_nomenclature_obs_technique;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_BIO', new.item #>> '{statut_biologique}')
-    INTO the_id_nomenclature_bio_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('ETA_BIO', new.item #>> '{etat_biologique}')
-    INTO the_id_nomenclature_bio_condition;
-    SELECT ref_nomenclatures.get_id_nomenclature('NATURALITE', new.item #>> '{naturalite}')
-    INTO the_id_nomenclature_naturalness;
-    SELECT ref_nomenclatures.get_id_nomenclature('PREUVE_EXIST', new.item #>> '{preuve_existante}')
-    INTO the_id_nomenclature_exist_proof;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_VALID', new.item #>> '{statut_validation}')
-    INTO the_id_nomenclature_valid_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('NIV_PRECIS', new.item #>> '{precision_diffusion}')
-    INTO the_id_nomenclature_diffusion_level;
-    SELECT ref_nomenclatures.get_id_nomenclature('STADE_VIE', new.item #>> '{stade_vie}')
-    INTO the_id_nomenclature_life_stage;
-    SELECT ref_nomenclatures.get_id_nomenclature('SEXE', new.item #>> '{sexe}')
-    INTO the_id_nomenclature_sex;
-    SELECT ref_nomenclatures.get_id_nomenclature('OBJ_DENBR', new.item #>> '{objet_denombrement}')
-    INTO the_id_nomenclature_obj_count;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYP_DENBR', new.item #>> '{type_denombrement}')
-    INTO the_id_nomenclature_type_count;
-    SELECT ref_nomenclatures.get_id_nomenclature('SENSIBILITE', new.item #>> '{niveau_sensibilite}')
-    INTO the_id_nomenclature_sensitivity;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_OBS', new.item #>> '{statut_observation}')
-    INTO the_id_nomenclature_observation_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('DEE_FLOU', new.item #>> '{floutage_dee}')
-    INTO the_id_nomenclature_blurring;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_SOURCE', new.item #>> '{statut_source}')
-    INTO the_id_nomenclature_source_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYP_INF_GEO', new.item #>> '{type_info_geo}')
-    INTO the_id_nomenclature_info_geo_type;
-    SELECT ref_nomenclatures.get_id_nomenclature('OCC_COMPORTEMENT', new.item #>> '{comportement}')
-    INTO the_id_nomenclature_behaviour;
-    SELECT ref_nomenclatures.get_id_nomenclature('STAT_BIOGEO', new.item #>> '{statut_biogeo}')
-    INTO the_id_nomenclature_biogeo_status;
-    SELECT new.item #>> '{reference_biblio}'
-    INTO the_reference_biblio;
-    SELECT new.item #>> '{nombre_min}'
-    INTO the_count_min;
-    SELECT new.item #>> '{nombre_max}'
-    INTO the_count_max;
-    SELECT new.item #>> '{cd_nom}'
-    INTO the_cd_nom;
-    SELECT new.item #>> '{cd_hab}'
-    INTO the_cd_hab;
-    SELECT new.item #>> '{nom_cite}'
-    INTO the_nom_cite;
-    SELECT new.item #>> '{version_taxref}'
-    INTO the_meta_v_taxref;
-    SELECT new.item #>> '{numero_preuve}'
-    INTO the_sample_number_proof;
-    SELECT new.item #>> '{preuve_numerique}'
-    INTO the_digital_proof;
-    SELECT new.item #>> '{preuve_non_numerique}'
-    INTO the_non_digital_proof;
-    SELECT new.item #>> '{altitude_min}'
-    INTO the_altitude_min;
-    SELECT new.item #>> '{altitude_max}'
-    INTO the_altitude_max;
-    SELECT new.item #>> '{profondeur_min}'
-    INTO the_depth_min;
-    SELECT new.item #>> '{profondeur_max}'
-    INTO the_depth_max;
-    SELECT new.item #>> '{nom_lieu}'
-    INTO the_place_name;
-    SELECT st_setsrid(st_geomfromtext(new.item #>> '{wkt_4326}'), 4326)
-    INTO _the_geom_4326;
-    SELECT st_centroid(_the_geom_4326)
-    INTO _the_geom_point;
-    SELECT st_transform(_the_geom_4326, _local_srid)
-    INTO _the_geom_local;
-    SELECT cast(new.item #>> '{precision}' AS INT)
-    INTO the_precision;
-    SELECT cast(new.item #>> '{date_debut}' AS DATE)
-    INTO the_date_min;
-    SELECT cast(new.item #>> '{date_fin}' AS DATE)
-    INTO the_date_max;
-    SELECT new.item #>> '{validateur}'
-    INTO the_validator;
-    SELECT new.item #>> '{comment_validation}'
-    INTO the_validation_comment;
-    SELECT new.item #>> '{observateurs}'
-    INTO the_observers;
-    SELECT new.item #>> '{determinateur}'
-    INTO the_determiner;
-    SELECT NULL
-    INTO the_id_digitiser;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYPE', new.item #>> '{label}')
-    INTO the_id_nomenclature_determination_method;
-    SELECT new.item #>> '{comment_releve}'
-    INTO the_comment_context;
-    SELECT new.item #>> '{comment_occurence}'
-    INTO the_comment_description;
-    SELECT NULL
-    INTO the_additional_data;
-    SELECT NULL
-    INTO the_meta_validation_date;
-    INSERT INTO gn_synthese.synthese ( unique_id_sinp
-                                     , unique_id_sinp_grp
-                                     , id_source
-                                     , entity_source_pk_value
-                                     , id_dataset
-                                     , id_nomenclature_geo_object_nature
-                                     , id_nomenclature_grp_typ
-                                     , grp_method
-                                     , id_nomenclature_obs_technique
-                                     , id_nomenclature_bio_status
-                                     , id_nomenclature_bio_condition
-                                     , id_nomenclature_naturalness
-                                     , id_nomenclature_exist_proof
-                                     , id_nomenclature_valid_status
-                                     , id_nomenclature_diffusion_level
-                                     , id_nomenclature_life_stage
-                                     , id_nomenclature_sex
-                                     , id_nomenclature_obj_count
-                                     , id_nomenclature_type_count
-                                     , id_nomenclature_sensitivity
-                                     , id_nomenclature_observation_status
-                                     , id_nomenclature_blurring
-                                     , id_nomenclature_source_status
-                                     , id_nomenclature_info_geo_type
-                                     , id_nomenclature_behaviour
-                                     , id_nomenclature_biogeo_status
-                                     , reference_biblio
-                                     , count_min
-                                     , count_max
-                                     , cd_nom
-                                     , cd_hab
-                                     , nom_cite
-                                     , meta_v_taxref
-                                     , sample_number_proof
-                                     , digital_proof
-                                     , non_digital_proof
-                                     , altitude_min
-                                     , altitude_max
-                                     , depth_min
-                                     , depth_max
-                                     , place_name
-                                     , the_geom_4326
-                                     , the_geom_point
-                                     , the_geom_local
-                                     , precision
-                                     , date_min
-                                     , date_max
-                                     , validator
-                                     , validation_comment
-                                     , observers
-                                     , determiner
-                                     , id_digitiser
-                                     , id_nomenclature_determination_method
-                                     , comment_context
-                                     , comment_description
-                                     , additional_data
-                                     , meta_validation_date
-                                     , last_action)
-    VALUES ( the_unique_id_sinp
-           , the_unique_id_sinp_grp
-           , the_id_source
-           , the_entity_source_pk_value
-           , the_id_dataset
-           , the_id_nomenclature_geo_object_nature
-           , the_id_nomenclature_grp_typ
-           , the_grp_method
-           , the_id_nomenclature_obs_technique
-           , the_id_nomenclature_bio_status
-           , the_id_nomenclature_bio_condition
-           , the_id_nomenclature_naturalness
-           , the_id_nomenclature_exist_proof
-           , the_id_nomenclature_valid_status
-           , the_id_nomenclature_diffusion_level
-           , the_id_nomenclature_life_stage
-           , the_id_nomenclature_sex
-           , the_id_nomenclature_obj_count
-           , the_id_nomenclature_type_count
-           , the_id_nomenclature_sensitivity
-           , the_id_nomenclature_observation_status
-           , the_id_nomenclature_blurring
-           , the_id_nomenclature_source_status
-           , the_id_nomenclature_info_geo_type
-           , the_id_nomenclature_behaviour
-           , the_id_nomenclature_biogeo_status
-           , the_reference_biblio
-           , the_count_min
-           , the_count_max
-           , the_cd_nom
-           , the_cd_hab
-           , the_nom_cite
-           , the_meta_v_taxref
-           , the_sample_number_proof
-           , the_digital_proof
-           , the_non_digital_proof
-           , the_altitude_min
-           , the_altitude_max
-           , the_depth_min
-           , the_depth_max
-           , the_place_name
-           , _the_geom_4326
-           , _the_geom_point
-           , _the_geom_local
-           , the_precision
-           , the_date_min
-           , the_date_max
-           , the_validator
-           , the_validation_comment
-           , the_observers
-           , the_determiner
-           , the_id_digitiser
-           , the_id_nomenclature_determination_method
-           , the_comment_context
-           , the_comment_description
-           , the_additional_data
-           , the_meta_validation_date
-           , 'I')
-    ON CONFLICT (id_source, entity_source_pk_value)
-        DO UPDATE SET unique_id_sinp                       = the_unique_id_sinp
-                    , unique_id_sinp_grp                   = the_unique_id_sinp_grp
-                    , id_source                            = the_id_source
-                    , entity_source_pk_value               = the_entity_source_pk_value
-                    , id_dataset                           = the_id_dataset
-                    , id_nomenclature_geo_object_nature    = the_id_nomenclature_geo_object_nature
-                    , id_nomenclature_grp_typ              = the_id_nomenclature_grp_typ
-                    , grp_method                           = the_grp_method
-                    , id_nomenclature_obs_technique        = the_id_nomenclature_obs_technique
-                    , id_nomenclature_bio_status           = the_id_nomenclature_bio_status
-                    , id_nomenclature_bio_condition        = the_id_nomenclature_bio_condition
-                    , id_nomenclature_naturalness          = the_id_nomenclature_naturalness
-                    , id_nomenclature_exist_proof          = the_id_nomenclature_exist_proof
-                    , id_nomenclature_valid_status         = the_id_nomenclature_valid_status
-                    , id_nomenclature_diffusion_level      = the_id_nomenclature_diffusion_level
-                    , id_nomenclature_life_stage           = the_id_nomenclature_life_stage
-                    , id_nomenclature_sex                  = the_id_nomenclature_sex
-                    , id_nomenclature_obj_count            = the_id_nomenclature_obj_count
-                    , id_nomenclature_type_count           = the_id_nomenclature_type_count
-                    , id_nomenclature_sensitivity          = the_id_nomenclature_sensitivity
-                    , id_nomenclature_observation_status   = the_id_nomenclature_observation_status
-                    , id_nomenclature_blurring             = the_id_nomenclature_blurring
-                    , id_nomenclature_source_status        = the_id_nomenclature_source_status
-                    , id_nomenclature_info_geo_type        = the_id_nomenclature_info_geo_type
-                    , id_nomenclature_behaviour            = the_id_nomenclature_behaviour
-                    , id_nomenclature_biogeo_status        = the_id_nomenclature_biogeo_status
-                    , reference_biblio                     = the_reference_biblio
-                    , count_min                            = the_count_min
-                    , count_max                            = the_count_max
-                    , cd_nom                               = the_cd_nom
-                    , cd_hab                               = the_cd_hab
-                    , nom_cite                             = the_nom_cite
-                    , meta_v_taxref                        = the_meta_v_taxref
-                    , sample_number_proof                  = the_sample_number_proof
-                    , digital_proof                        = the_digital_proof
-                    , non_digital_proof                    = the_non_digital_proof
-                    , altitude_min                         = the_altitude_min
-                    , altitude_max                         = the_altitude_max
-                    , depth_min                            = the_depth_min
-                    , depth_max                            = the_depth_max
-                    , place_name                           = the_place_name
-                    , the_geom_4326                        = _the_geom_4326
-                    , the_geom_point                       = _the_geom_point
-                    , the_geom_local                       = _the_geom_local
-                    , precision                            = the_precision
-                    , date_min                             = the_date_min
-                    , date_max                             = the_date_max
-                    , validator                            = the_validator
-                    , validation_comment                   = the_validation_comment
-                    , observers                            = the_observers
-                    , determiner                           = the_determiner
-                    , id_digitiser                         = the_id_digitiser
-                    , id_nomenclature_determination_method = the_id_nomenclature_determination_method
-                    , comment_context                      = the_comment_context
-                    , comment_description                  = the_comment_description
-                    , additional_data                      = the_additional_data
-                    , meta_validation_date                 = the_meta_validation_date
-                    , last_action                          = 'U';
-    RETURN new;
-END;
-$func$
-;
-
-COMMENT ON FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_cd_nomenclature () IS 'Trigger function to upsert datas from import to synthese'
-;
-
-DROP TRIGGER IF EXISTS tri_c_upsert_data_to_geonature_with_cd_nomenclature ON gn2pg_import.data_json
-;
-
-CREATE TRIGGER tri_c_upsert_data_to_geonature_with_cd_nomenclature
-    AFTER INSERT OR UPDATE
-    ON gn2pg_import.data_json
-    FOR EACH ROW
-    WHEN (new.type LIKE 'synthese_with_cd_nomenclature')
-EXECUTE PROCEDURE gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_cd_nomenclature()
-;
-
-
-DROP FUNCTION IF EXISTS gn2pg_import.fct_tri_c_delete_data_from_geonature() CASCADE;
-
-CREATE OR REPLACE FUNCTION gn2pg_import.fct_tri_c_delete_data_from_geonature()
-    RETURNS TRIGGER
-    LANGUAGE plpgsql
-AS
-$func$
-BEGIN
-    DELETE
-    FROM gn_synthese.synthese
-    WHERE (old.item #>> '{id_synthese}', gn2pg_import.fct_c_get_or_insert_source(old.source)) =
-          (synthese.entity_source_pk_value, synthese.id_source);
-    IF NOT found THEN
-        RETURN NULL;
-    END IF;
-    RETURN old;
-END;
-$func$
-;
-
-
-COMMENT ON FUNCTION gn2pg_import.fct_tri_c_delete_data_from_geonature() IS 'Trigger function to delete datas'
-;
-
-/* BEGIN: SYNTHESE WITH METADATA*/
 
 DROP FUNCTION IF EXISTS gn2pg_import.fct_c_insert_ds_territories(_id_ds INTEGER, _territories JSONB);
 
@@ -1211,7 +410,8 @@ $$;
 
 COMMENT ON FUNCTION gn2pg_import.fct_c_get_or_insert_source(TEXT) IS 'function to basically create new sources';
 
-CREATE OR REPLACE FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_metadata() RETURNS TRIGGER
+-- UPSERT
+CREATE OR REPLACE FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature() RETURNS TRIGGER
     LANGUAGE plpgsql
 AS
 $$
@@ -1276,7 +476,6 @@ DECLARE
     the_additional_data                      JSONB;
     the_meta_validation_date                 TIMESTAMP;
 BEGIN
-    RAISE DEBUG 'Update synthese_with_metadata';
     SELECT find_srid('gn_synthese', 'synthese', 'the_geom_local')
     INTO _local_srid;
     SELECT new.uuid
@@ -1285,54 +484,148 @@ BEGIN
     INTO the_unique_id_sinp_grp;
     SELECT gn2pg_import.fct_c_get_or_insert_source(new.source)
     INTO the_id_source;
-    --     id_module                                INT;
     SELECT new.item #>> '{id_synthese}'
     INTO the_entity_source_pk_value;
-    SELECT gn2pg_import.fct_c_get_or_insert_af_from_af_jsondata(new.item #> '{ca_data}', new.source)
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_metadata' THEN gn2pg_import.fct_c_get_or_insert_af_from_af_jsondata(new.item #> '{ca_data}', new.source)
+            ELSE gn2pg_import.fct_c_get_or_insert_basic_af_from_uuid_name(cast(new.item #>> '{ca_uuid}' AS UUID), new.item #>> '{ca_nom}')
+        END AS the_id_af
     INTO the_id_af;
-    SELECT gn2pg_import.fct_c_get_or_insert_dataset_from_jsondata(new.item #> '{jdd_data}', the_id_af, new.source)
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_metadata' then gn2pg_import.fct_c_get_or_insert_dataset_from_jsondata(
+                new.item #> '{jdd_data}', 
+                the_id_af, 
+                new.source
+            )
+            ELSE gn2pg_import.fct_c_get_or_insert_basic_dataset_from_uuid_name(
+                cast(new.item #>> '{jdd_uuid}' AS UUID),
+                new.item #>> '{jdd_nom}', 
+                the_id_af
+            )
+        END AS id_dataset
     INTO the_id_dataset;
-    SELECT ref_nomenclatures.get_id_nomenclature('NAT_OBJ_GEO', new.item #>> '{nature_objet_geo}')
+    SELECT 
+        CASE new.type 
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('NAT_OBJ_GEO',  new.item #>> '{nature_objet_geo}')
+            ELSE ref_nomenclatures.get_id_nomenclature('NAT_OBJ_GEO',  new.item #>> '{nature_objet_geo}')
+        END AS id_nomenclature_geo_object_nature
     INTO the_id_nomenclature_geo_object_nature;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYP_GRP', new.item #>> '{type_regroupement}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('TYP_GRP',  new.item #>> '{type_regroupement}')
+            ELSE ref_nomenclatures.get_id_nomenclature('TYP_GRP',  new.item #>> '{type_regroupement}')
+        END AS id_nomenclature_grp_typ
     INTO the_id_nomenclature_grp_typ;
     SELECT new.item #>> '{methode_regroupement}'
     INTO the_grp_method;
-    SELECT ref_nomenclatures.get_id_nomenclature('METH_OBS', new.item #>> '{technique_obs}')
+    SELECT 
+        CASE new.type 
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('METH_OBS',  new.item #>> '{technique_obs}')
+            ELSE ref_nomenclatures.get_id_nomenclature('METH_OBS',  new.item #>> '{technique_obs}')
+        END AS id_nomenclature_obs_technique
     INTO the_id_nomenclature_obs_technique;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_BIO', new.item #>> '{statut_biologique}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_BIO',  new.item #>> '{statut_biologique}')
+            ELSE ref_nomenclatures.get_id_nomenclature('STATUT_BIO',  new.item #>> '{statut_biologique}')
+        END AS id_nomenclature_bio_status
     INTO the_id_nomenclature_bio_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('ETA_BIO', new.item #>> '{etat_biologique}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('ETA_BIO',  new.item #>> '{etat_biologique}')
+            ELSE ref_nomenclatures.get_id_nomenclature('ETA_BIO',  new.item #>> '{etat_biologique}')
+        END AS id_nomenclature_bio_condition
     INTO the_id_nomenclature_bio_condition;
-    SELECT ref_nomenclatures.get_id_nomenclature('NATURALITE', new.item #>> '{naturalite}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('NATURALITE',  new.item #>> '{naturalite}')
+            ELSE ref_nomenclatures.get_id_nomenclature('NATURALITE',  new.item #>> '{naturalite}')
+        END AS id_nomenclature_naturalness
     INTO the_id_nomenclature_naturalness;
-    SELECT ref_nomenclatures.get_id_nomenclature('PREUVE_EXIST', new.item #>> '{preuve_existante}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('PREUVE_EXIST',  new.item #>> '{preuve_existante}')
+            ELSE ref_nomenclatures.get_id_nomenclature('PREUVE_EXIST',  new.item #>> '{preuve_existante}')
+        END AS id_nomenclature_exist_proof
     INTO the_id_nomenclature_exist_proof;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_VALID', new.item #>> '{statut_validation}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_VALID',  new.item #>> '{statut_validation}')
+            ELSE ref_nomenclatures.get_id_nomenclature('STATUT_VALID',  new.item #>> '{statut_validation}')
+        END AS id_nomenclature_valid_status
     INTO the_id_nomenclature_valid_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('NIV_PRECIS', new.item #>> '{precision_diffusion}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('NIV_PRECIS',  new.item #>> '{precision_diffusion}')
+            ELSE ref_nomenclatures.get_id_nomenclature('NIV_PRECIS', new.item #>> '{precision_diffusion}')
+        END AS id_nomenclature_diffusion_level
     INTO the_id_nomenclature_diffusion_level;
-    SELECT ref_nomenclatures.get_id_nomenclature('STADE_VIE', new.item #>> '{stade_vie}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('STADE_VIE',  new.item #>> '{stade_vie}')
+            ELSE ref_nomenclatures.get_id_nomenclature('STADE_VIE',  new.item #>> '{stade_vie}')
+        END AS id_nomenclature_life_stage
     INTO the_id_nomenclature_life_stage;
-    SELECT ref_nomenclatures.get_id_nomenclature('SEXE', new.item #>> '{sexe}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('SEXE',  new.item #>> '{sexe}')
+            ELSE ref_nomenclatures.get_id_nomenclature('SEXE',  new.item #>> '{sexe}')
+        END AS id_nomenclature_sex
     INTO the_id_nomenclature_sex;
-    SELECT ref_nomenclatures.get_id_nomenclature('OBJ_DENBR', new.item #>> '{objet_denombrement}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('OBJ_DENBR',  new.item #>> '{objet_denombrement}')
+            ELSE ref_nomenclatures.get_id_nomenclature('OBJ_DENBR',  new.item #>> '{objet_denombrement}')
+        END AS id_nomenclature_obj_count
     INTO the_id_nomenclature_obj_count;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYP_DENBR', new.item #>> '{type_denombrement}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('TYP_DENBR',  new.item #>> '{type_denombrement}')
+            ELSE ref_nomenclatures.get_id_nomenclature('TYP_DENBR',  new.item #>> '{type_denombrement}')
+        END AS id_nomenclature_type_count
     INTO the_id_nomenclature_type_count;
-    SELECT ref_nomenclatures.get_id_nomenclature('SENSIBILITE', new.item #>> '{niveau_sensibilite}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('SENSIBILITE',  new.item #>> '{niveau_sensibilite}')
+            ELSE ref_nomenclatures.get_id_nomenclature('SENSIBILITE',  new.item #>> '{niveau_sensibilite}')
+        END AS id_nomenclature_sensitivity
     INTO the_id_nomenclature_sensitivity;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_OBS', new.item #>> '{statut_observation}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_OBS',  new.item #>> '{statut_observation}')
+            ELSE ref_nomenclatures.get_id_nomenclature('STATUT_OBS',  new.item #>> '{statut_observation}')
+        END AS id_nomenclature_observation_status
     INTO the_id_nomenclature_observation_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('DEE_FLOU', new.item #>> '{floutage_dee}')
+    SELECT CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('DEE_FLOU',  new.item #>> '{floutage_dee}')
+            ELSE ref_nomenclatures.get_id_nomenclature('DEE_FLOU',  new.item #>> '{floutage_dee}')
+        END AS id_nomenclature_blurring
     INTO the_id_nomenclature_blurring;
-    SELECT ref_nomenclatures.get_id_nomenclature('STATUT_SOURCE', new.item #>> '{statut_source}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('STATUT_SOURCE',  new.item #>> '{statut_source}')
+            ELSE ref_nomenclatures.get_id_nomenclature('STATUT_SOURCE',  new.item #>> '{statut_source}')
+        END AS id_nomenclature_source_status
     INTO the_id_nomenclature_source_status;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYP_INF_GEO', new.item #>> '{type_info_geo}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('TYP_INF_GEO',  new.item #>> '{type_info_geo}')
+            ELSE ref_nomenclatures.get_id_nomenclature('TYP_INF_GEO',  new.item #>> '{type_info_geo}')
+        END AS id_nomenclature_info_geo_type
     INTO the_id_nomenclature_info_geo_type;
-    SELECT ref_nomenclatures.get_id_nomenclature('OCC_COMPORTEMENT', new.item #>> '{comportement}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('OCC_COMPORTEMENT',  new.item #>> '{comportement}')
+            ELSE ref_nomenclatures.get_id_nomenclature('OCC_COMPORTEMENT',  new.item #>> '{comportement}')
+        END AS id_nomenclature_behaviour
     INTO the_id_nomenclature_behaviour;
-    SELECT ref_nomenclatures.get_id_nomenclature('STAT_BIOGEO', new.item #>> '{statut_biogeo}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('STAT_BIOGEO',  new.item #>> '{statut_biogeo}')
+            ELSE ref_nomenclatures.get_id_nomenclature('STAT_BIOGEO',  new.item #>> '{statut_biogeo}') 
+        END AS id_nomenclature_biogeo_status
     INTO the_id_nomenclature_biogeo_status;
     SELECT new.item #>> '{reference_biblio}'
     INTO the_reference_biblio;
@@ -1386,7 +679,11 @@ BEGIN
     INTO the_determiner;
     SELECT NULL
     INTO the_id_digitiser;
-    SELECT ref_nomenclatures.get_id_nomenclature('TYPE', new.item #>> '{label}')
+    SELECT 
+        CASE new.type
+            WHEN 'synthese_with_label' THEN gn2pg_import.fct_c_get_id_nomenclature_from_label('TYPE',  new.item #>> '{label}')
+            ELSE ref_nomenclatures.get_id_nomenclature('TYPE',  new.item #>> '{label}')
+        END AS id_nomenclature_determination_method
     INTO the_id_nomenclature_determination_method;
     SELECT new.item #>> '{comment_releve}'
     INTO the_comment_context;
@@ -1577,20 +874,16 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_metadata() IS 'Trigger function to upsert datas from import to synthese';
+COMMENT ON FUNCTION gn2pg_import.fct_tri_c_upsert_data_to_geonature() IS 'Trigger function to upsert datas from import to synthese';
 
-DROP TRIGGER IF EXISTS tri_c_upsert_data_to_geonature_with_metadata ON gn2pg_import.data_json;
-
-CREATE TRIGGER tri_c_upsert_data_to_geonature_with_metadata
+DROP TRIGGER IF EXISTS tri_c_upsert_data_to_geonature ON gn2pg_import.data_json;
+CREATE TRIGGER tri_c_upsert_data_to_geonature
     AFTER INSERT OR UPDATE
     ON gn2pg_import.data_json
     FOR EACH ROW
-    WHEN (new.type::TEXT ~~ 'synthese_with_metadata'::TEXT)
-EXECUTE PROCEDURE gn2pg_import.fct_tri_c_upsert_data_to_geonature_with_metadata();
+    EXECUTE PROCEDURE gn2pg_import.fct_tri_c_upsert_data_to_geonature();
 
-
-/* END: SYNTHESE WITH METADATA */
-
+-- DELETE
 CREATE OR REPLACE FUNCTION gn2pg_import.fct_tri_c_delete_data_from_geonature() RETURNS TRIGGER
     LANGUAGE plpgsql
 AS
@@ -1606,20 +899,14 @@ BEGIN
     RETURN old;
 END;
 $$;
-
 COMMENT ON FUNCTION gn2pg_import.fct_tri_c_delete_data_from_geonature() IS 'Trigger function to delete datas';
 
-
 DROP TRIGGER IF EXISTS tri_c_delete_data_from_geonature ON gn2pg_import.data_json;
-;
-
 CREATE TRIGGER tri_c_delete_data_from_geonature
     AFTER DELETE
     ON gn2pg_import.data_json
     FOR EACH ROW
     WHEN (old.type IN ('synthese_with_label', 'synthese_with_cd_nomenclature', 'synthese_with_metadata'))
-EXECUTE PROCEDURE gn2pg_import.fct_tri_c_delete_data_from_geonature()
-;
+EXECUTE PROCEDURE gn2pg_import.fct_tri_c_delete_data_from_geonature();
 
-COMMIT
-;
+COMMIT;


### PR DESCRIPTION
## Contexte
Dans le cadre d'une prestation avec le Parc National des Ecrins pour le SINP, les performances de la mise à jour de la synthèse ont été évaluées avec un traitement de type `AFTER EACH ROW` et un traitement de type `AFTER EACH STATEMENT` (voir #40 pour plus de détails).

## Solution proposée
Au total, trois solutions ont été évaluées. Aucune ne permettait d'améliorer le temps d'exécution. 
Il a également été identifié que le code pouvait être mutualisé permettant le passage de trois triggers/fonctions à un. Cela peut permettre un maintien plus facile du code.
La solution proposée ici correspond donc à la solution n°3 présentée dans l'issue #40 : "Conservation du traitement par ligne et mise en place d'un trigger unique quelque soit le type de données".

## Perspectives
De nombreuses autres fonctions sont présentes dans le fichier `to_gnsynthese.sql`. Il pourrait être intéressant de les examiner pour identifier si elles pourraient être optimisées afin d'accélérer l'exécution globale de la mise à jour de la synthèse.