### PR TITLE
id_nomenclature_determination_method : fix source field name

### DIFF
--- a/gn2pg/data/to_gnsynthese.sql
+++ b/gn2pg/data/to_gnsynthese.sql
@@ -1169,9 +1169,9 @@ BEGIN
     SELECT
         CASE NEW.type
         WHEN 'synthese_with_label' THEN
-            gn2pg_import.fct_c_get_id_nomenclature_from_label ('TYPE' , NEW.item #>> '{label}')
+            gn2pg_import.fct_c_get_id_nomenclature_from_label ('TYPE' , NEW.item #>> '{methode_determination}')
         ELSE
-            gn2pg_import.fct_c_get_id_nomenclature ('TYPE' , NEW.item #>> '{label}')
+            gn2pg_import.fct_c_get_id_nomenclature ('TYPE' , NEW.item #>> '{methode_determination}')
 	END AS id_nomenclature_determination_method INTO
 	    the_id_nomenclature_determination_method;
     SELECT


### PR DESCRIPTION
Une micro-PR qui corrige une incohérence entre les ressources standardsau niveau du champ `id_nomenclature_determination_method` : le script d'import `to_gnsynthese.sql` cherche un champ `label`, alors que les standards exposent un champ `methode_determination`.

Corrigé dans la version adaptée pur Clicnat : ça fonctionne.